### PR TITLE
add --name src  option to gclient config command

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ Refer to chromium instructions for each platform for other prerequisites.
 
 Create a working directory, enter it, and run:
 
-    gclient config https://chromium.googlesource.com/libyuv/libyuv
+    gclient --name src config https://chromium.googlesource.com/libyuv/libyuv
     gclient sync
 
 


### PR DESCRIPTION
This is necessary for the rest of the build scripts to work.  The scripts are expecting `libyuv` to be in a folder called `src`.